### PR TITLE
Use Centos 7 box in sample Vagrantfile

### DIFF
--- a/sample_Vagrantfile
+++ b/sample_Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure(2) do |config|
   # Vagrant configuration options are fully documented at
   # https://docs.vagrantup.com.
 
-  config.vm.box = "ubuntu/trusty64"
-  config.vm.box_url = "https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box"
+  config.vm.box = "centos7"
+  config.vm.box_url = "http://camp.curationexperts.com/boxes/centos70-x86_64-20151111.box"
 
   # Forwarded port mappings allow access to a specific port on the guest vm
   # from a port on the host machine - to see your vm's port 80, use localhost:8484


### PR DESCRIPTION
The sample Vagrantfile should probably point to a Centos box instead of an Ubuntu box since the rest of the repo is Centos flavored
