### PR TITLE
[marmotta] fix name of SHA variable

### DIFF
--- a/roles/marmotta/defaults/main.yml
+++ b/roles/marmotta/defaults/main.yml
@@ -4,7 +4,7 @@ project_name: alex2
 tomcat: /usr/share/tomcat
 
 marmotta_ver: 3.3.0
-marmotta_sha: 34c37281b6875ea95da391ae5bbe059f31091f3c6bf2529539241b35690c84b0
+marmotta_256: 34c37281b6875ea95da391ae5bbe059f31091f3c6bf2529539241b35690c84b0
 marmotta_home: /opt/marmotta
 marmotta_group: marmotta
 marmotta_user: marmotta


### PR DESCRIPTION
I probably did this during a rebase :see_no_evil: 
