### PR TITLE
have ldap/ezid roles write to secrets.yml

### DIFF
--- a/roles/ezid/tasks/main.yml
+++ b/roles/ezid/tasks/main.yml
@@ -4,3 +4,19 @@
   become: yes
   template: src=ezid.yml.j2 dest={{ config_path }}/ezid.yml \
             owner={{ deploy_user }} group={{ deploy_group }} backup=no
+
+# encoding the YAML replacement in base64 since colons in YAML strings cause problems
+- name: write Ezid user to secrets file
+  become: yes
+  shell: sed -i "$(echo 'L1woZGVmYXVsdDpcIFwmZGVmYXVsdFwpL2NkZWZhdWx0OlwgXCZkZWZhdWx0XG5cIFwgZXppZF91c2VyOlwgCg==' | base64 -d)$(echo '{{ ezid_user }}')" \
+         {{ project_base }}/{{ project_name }}/shared/config/secrets.yml
+
+- name: write Ezid password to secrets file
+  become: yes
+  shell: sed -i "$(echo 'L1woZGVmYXVsdDpcIFwmZGVmYXVsdFwpL2NkZWZhdWx0OlwgXCZkZWZhdWx0XG5cIFwgZXppZF9wYXNzOlwgCg==' | base64 -d)$(echo '{{ ezid_user }}')" \
+         {{ project_base }}/{{ project_name }}/shared/config/secrets.yml
+
+- name: write Ezid shoulder to secrets file
+  become: yes
+  shell: sed -i "$(echo 'L1woZGVmYXVsdDpcIFwmZGVmYXVsdFwpL2NkZWZhdWx0OlwgXCZkZWZhdWx0XG5cIFwgZXppZF9kZWZhdWx0X3Nob3VsZGVyOlwgCg==' | base64 -d)$(echo '{{ ezid_default_shoulder }}')" \
+         {{ project_base }}/{{ project_name }}/shared/config/secrets.yml

--- a/roles/ezid/templates/ezid.yml.j2
+++ b/roles/ezid/templates/ezid.yml.j2
@@ -1,9 +1,15 @@
-# This config file was created by Ansible
-# development:
-# test:
-production:
+default: &default
   host:             {{ ezid_host }}
   port:             {{ ezid_port }}
-  user:             {{ ezid_user }}
-  password:         {{ ezid_password }}
-  default_shoulder: {{ ezid_default_shoulder }}
+  user:             <%= Rails.application.secrets.ezid_user %>
+  password:         <%= Rails.application.secrets.ezid_pass %>
+  ezid_default_shoulder: <%= Rails.application.secrets.ezid_default_shoulder %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -4,3 +4,14 @@
   become: yes
   template: src=ldap.yml.j2 dest={{ config_path }}/ldap.yml \
             owner={{ deploy_user }} group={{ deploy_group }} backup=no
+
+# encoding the YAML replacement in base64 since colons in YAML strings cause problems
+- name: write LDAP user to secrets file
+  become: yes
+  shell: sed -i "$(echo 'L1woZGVmYXVsdDpcIFwmZGVmYXVsdFwpL2NkZWZhdWx0OlwgXCZkZWZhdWx0XG5cIFwgbGRhcF91c2VyOlwgCg==' | base64 -d)$(echo '{{ ldap_admin_user }}')" \
+         {{ project_base }}/{{ project_name }}/shared/config/secrets.yml
+
+- name: write LDAP password to secrets file
+  become: yes
+  shell: sed -i "$(echo 'L1woZGVmYXVsdDpcIFwmZGVmYXVsdFwpL2NkZWZhdWx0OlwgXCZkZWZhdWx0XG5cIFwgbGRhcF9wYXNzOlwgCg==' | base64 -d)$(echo '{{ ldap_admin_password }}')" \
+         {{ project_base }}/{{ project_name }}/shared/config/secrets.yml

--- a/roles/ldap/templates/ldap.yml.j2
+++ b/roles/ldap/templates/ldap.yml.j2
@@ -1,13 +1,12 @@
-## Environment
 default: &default
   attribute: {{ ldap_attribute }}
   base: {{ ldap_base }}
   group_base: {{ ldap_group_base }}
 
 production:
+  <<: *default
   host: {{ ldap_host }}
   port: {{ ldap_port }}
-  admin_user: {{ ldap_admin_user }}
-  admin_password: {{ ldap_admin_password }}
+  admin_user: <%= Rails.application.secrets.ldap_user %>
+  admin_password: <%= Rails.application.secrets.ldap_pass %>
   ssl: {{ ldap_ssl }}
-  <<: *default

--- a/roles/services/templates/secrets.yml.j2
+++ b/roles/services/templates/secrets.yml.j2
@@ -1,20 +1,13 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key is used for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rake secret` to generate a secure secret key.
-
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
-
-development:
-  secret_key_base: 09183a6f123c0440955e283875c843776d8f4ff1d50a233c169b3a456c1b673fc53c93abff85f8748fcae3c04006d202b000800492d343aef3a6066268e08a81
+default: &default
+  fedora_user: fedoraAdmin
+  hydra_pg_pass: {{ hydra_pg_pass }}
+  pg_pass: {{ pg_pass }}
+  secret_key_base: {{ rails_secret_key_base }}
 
 test:
-  secret_key_base: 4d600c73173c5ef7ff0425f41fd04157d7a6e0fd5336d07a7993534590eb8dc92301489118c0e728e72c627a924788dcf1a72751ec01ea4715d9885cb2a9ae27
+  <<: *default
+  fedora_pass: fedoraAdmin
 
 production:
-  secret_key_base: {{ rails_secret_key_base }}
+  <<: *default
+  fedora_pass: {{ fedora_pass }}


### PR DESCRIPTION
This was the only way I could think of to have Ansible tasks write specific lines (containing colons) to specific places in `secrets.yml` without adding to the secrets template.
