### PR TITLE
always generate passenger.conf

### DIFF
--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -20,7 +20,7 @@
   shell: passenger-install-apache2-module --auto creates=/usr/local/lib/ruby/gems/{{ ruby_abi }}.0/gems/passenger-{{ passenger_ver }}/buildout/apache2/mod_passenger.so
 
 - name: generate passenger.conf file
-  shell: passenger-install-apache2-module --snippet > /etc/httpd/conf.d/passenger.conf creates=/etc/httpd/conf.d/passenger.conf
+  shell: passenger-install-apache2-module --snippet > /etc/httpd/conf.d/passenger.conf
 
 - name: restart apache
   service: name=httpd state=restarted


### PR DESCRIPTION
It contains the version of Passenger, so if the playbook is re-run after
an upgrade Apache will fail to start:

```
Mar 11 23:16:00 adrlstage.library.ucsb.edu systemd[1]: Starting The Apache HTTP Server...
Mar 11 23:16:00 adrlstage.library.ucsb.edu httpd[25485]: httpd: Syntax error on line 353 of /etc/httpd/conf/httpd.conf: Syntax error on line 1 of /etc/httpd/conf.d/passenger.conf: Cannot load /usr/local/lib/ruby/gems/2.2.0/gems/passenger-5.0.10/buildout/apache2/mod_passenger.so into server: /usr/local/lib/ruby/gems/2.2.0/gems/passenger-5.0.10/buildout/apache2/mod_passenger.so: cannot open shared object file: No such file or directory
```
